### PR TITLE
[FIX] UnicodeDecodeError: 'cp950' codec can't decode error

### DIFF
--- a/src/modules/checkpath.py
+++ b/src/modules/checkpath.py
@@ -35,7 +35,7 @@ def checkpath(self, mode):
                 self.Globaldir = os.path.join(new_path, "data", "yuzu")
 
             config_parser = configparser.ConfigParser()
-            config_parser.read(self.configdir)
+            config_parser.read(self.configdir, encoding="utf-8")
             self.nand_dir = os.path.normpath(config_parser.get('Data%20Storage', 'nand_directory', fallback=f'{self.Globaldir}/nand'))
             self.load_dir = os.path.normpath(config_parser.get('Data%20Storage', 'load_directory', fallback=f'{self.Globaldir}/load'))
             if self.load_dir.startswith('"'):
@@ -77,7 +77,7 @@ def checkpath(self, mode):
                 self.configdir = os.path.join(yuzupath, "../user/config/qt-config.ini")
                 self.TOTKconfig = os.path.join(self.configdir, "../custom/0100F2C0115B6000.ini")
                 config_parser = configparser.ConfigParser()
-                config_parser.read(self.configdir)
+                config_parser.read(self.configdir, encoding="utf-8")
                 self.nand_dir = os.path.normpath(config_parser.get('Data%20Storage', 'nand_directory', fallback=f'{os.path.join(yuzupath, "../user/nand")}'))
                 self.load_dir = os.path.join(os.path.normpath(config_parser.get('Data%20Storage', 'load_directory', fallback=f'{os.path.join(yuzupath, "../user/nand")}')), "0100F2C0115B6000")
                 self.Yuzudir = os.path.join(home_directory, "AppData", "Roaming", "yuzu", "load", "0100F2C0115B6000")
@@ -112,7 +112,7 @@ def checkpath(self, mode):
                 self.configdir = os.path.join(self.Globaldir, "config", "qt-config.ini")
                 self.TOTKconfig = os.path.join(self.configdir, "../custom/0100F2C0115B6000.ini")
                 config_parser = configparser.ConfigParser()
-                config_parser.read(self.configdir)
+                config_parser.read(self.configdir, encoding="utf-8")
                 self.nand_dir = os.path.normpath(config_parser.get('Data%20Storage', 'nand_directory', fallback=f'{self.Globaldir}/nand'))
                 self.load_dir = os.path.join(os.path.normpath(config_parser.get('Data%20Storage', 'load_directory', fallback=f'{self.Globaldir}/load')), "0100F2C0115B6000")
                 self.Yuzudir = os.path.join(home_directory, "AppData", "Roaming", "yuzu", "load", "0100F2C0115B6000")


### PR DESCRIPTION
For users in the Chinese region, opening the Windows executable file would result in an immediate crash. The actual error displayed was:
```bash
Traceback (most recent call last):
  File "run.py", line 9, in <module>
  File "form.py", line 654, in load_canvas
  File "form.py", line 93, in create_canvas
  File "modules\checkpath.py", line 115, in checkpath
  File "configparser.py", line 713, in read
  File "configparser.py", line 1036, in _read
UnicodeDecodeError: 'cp950' codec can't decode byte 0xe7 in position 4972: illegal multibyte sequence
[12352] Failed to execute script 'run' due to unhandled exception!
```
By ensuring that all files are encoded using UTF-8 and recompiling, the error has been fixed, and the files can now be opened without any issues.